### PR TITLE
Set proxy-body-size to 99mb

### DIFF
--- a/deploy/ingress.yml
+++ b/deploy/ingress.yml
@@ -3,12 +3,16 @@ kind: Ingress
 metadata:
   name: memuy-ingress
   namespace: memuy
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "99m"
+---
 spec:
   rules:
-  - host: api.memuy.com
-    http:
-      paths:
-      - backend:
-          serviceName: memuy-app
-          servicePort: 8000
+    - host: api.memuy.com
+      http:
+        paths:
+          - backend:
+              serviceName: memuy-app
+              servicePort: 8000
 ---
+


### PR DESCRIPTION
Increase the max upload file size to 99mb by changing proxy-body-size on the nginx instance behinh ingress.